### PR TITLE
fix(cond): Add lastHeartbeatTime to conditions

### DIFF
--- a/conditions/v1/conditions.go
+++ b/conditions/v1/conditions.go
@@ -15,6 +15,7 @@ func SetStatusCondition(conditions *[]Condition, newCondition Condition) {
 	existingCondition := FindStatusCondition(*conditions, newCondition.Type)
 	if existingCondition == nil {
 		newCondition.LastTransitionTime = metav1.NewTime(time.Now())
+		newCondition.LastHeartbeatTime = metav1.NewTime(time.Now())
 		*conditions = append(*conditions, newCondition)
 		return
 	}
@@ -26,6 +27,7 @@ func SetStatusCondition(conditions *[]Condition, newCondition Condition) {
 
 	existingCondition.Reason = newCondition.Reason
 	existingCondition.Message = newCondition.Message
+	existingCondition.LastHeartbeatTime = metav1.NewTime(time.Now())
 }
 
 // RemoveStatusCondition removes the corresponding conditionType from conditions.


### PR DESCRIPTION
lastHeartbeatTime is meant to track the last time that an update was
given to a particular condition. One scenario where this is useful is
where an operator is managing a resource that is in a "Degraded" state
lastHeartbeatTime would let an admin know how recently that state has
been observed.

Unit tests were updated to test the change in logic.

Fixes #3