### PR TITLE
conditions: add SetStatusConditionNoHeartbeat

### DIFF
--- a/conditions/v1/conditions.go
+++ b/conditions/v1/conditions.go
@@ -30,6 +30,28 @@ func SetStatusCondition(conditions *[]Condition, newCondition Condition) {
 	existingCondition.LastHeartbeatTime = metav1.NewTime(time.Now())
 }
 
+// SetStatusConditionNoHearbeat sets the corresponding condition in conditions to newCondition
+// without setting lastHeartbeatTime.
+func SetStatusConditionNoHeartbeat(conditions *[]Condition, newCondition Condition) {
+	if conditions == nil {
+		conditions = &[]Condition{}
+	}
+	existingCondition := FindStatusCondition(*conditions, newCondition.Type)
+	if existingCondition == nil {
+		newCondition.LastTransitionTime = metav1.NewTime(time.Now())
+		*conditions = append(*conditions, newCondition)
+		return
+	}
+
+	if existingCondition.Status != newCondition.Status {
+		existingCondition.Status = newCondition.Status
+		existingCondition.LastTransitionTime = metav1.NewTime(time.Now())
+	}
+
+	existingCondition.Reason = newCondition.Reason
+	existingCondition.Message = newCondition.Message
+}
+
 // RemoveStatusCondition removes the corresponding conditionType from conditions.
 func RemoveStatusCondition(conditions *[]Condition, conditionType ConditionType) {
 	if conditions == nil {


### PR DESCRIPTION
This will make it possible for consumers of this library to set status
conditions without managing the lastHeartbeatTime.

The reason for this change comes from the
[api-conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md)
warning about `LastHeartbeatTime`:

> Use the LastHeartbeatTime with great caution - frequent changes to this field can cause a large fan-out effect for some resources.